### PR TITLE
Add actionable error messages with flag suggestions and HTTP status hints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Core quality improvements that make the tool feel solid and production-ready.
 - ~~Validate `--timeout` is a positive number~~ ✓
 - ~~Validate `--max-redirects` is a non-negative integer~~ ✓
 - ~~Validate `--retry` and `--retry-delay` values~~ ✓
-- [ ] Improve error messages with actionable suggestions (e.g., "Did you mean --follow?")
+- ~~Improve error messages with actionable suggestions (e.g., "Did you mean --follow?")~~ ✓
 - [ ] Add `--retry-all-errors` flag to retry on HTTP errors (not just network errors)
 
 ### Redirect Handling

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -7,6 +7,7 @@ import {
   type FetchOptions,
 } from '../../core/http/client'
 import { stdout, streamDownload } from '../../lib/output/formatters'
+import { getHttpStatusHint } from '../../lib/utils/errors'
 import { type ResponseData } from '../../types'
 
 export async function executeRequest(url: string, options: FetchOptions) {
@@ -41,7 +42,18 @@ export async function executeRequest(url: string, options: FetchOptions) {
   const finalUrl = buildUrl(url, options.query)
   await stdout(data, options, { url: finalUrl, method })
 
+  // Hint: suggest --follow when a redirect is returned without following
+  if (!options.follow && data.status >= 300 && data.status < 400 && redirectUrl) {
+    console.error(
+      `HTTP ${data.status} — redirected to ${redirectUrl}\n  Hint: Use -L or --follow to automatically follow redirects.`,
+    )
+  }
+
   if (options.fail && data.status >= 400) {
+    const hint = getHttpStatusHint(data.status)
+    if (hint) {
+      console.error(`HTTP ${data.status} error\n  Hint: ${hint}`)
+    }
     process.exit(HTTP_ERROR_EXIT_CODE)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ export async function main(): Promise<void> {
 
     const rawUrl = positionals[positionals.length - 1] || alias?.url
     if (!rawUrl) {
-      console.error('No URL provided')
+      console.error(
+        'No URL provided.\n  Usage: curly <url>\n  Run curly --help for more information.',
+      )
       process.exit(1)
     }
 
@@ -123,7 +125,11 @@ export async function main(): Promise<void> {
     const hasData = (mergedData && mergedData.length > 0) || cliFlags['data-raw']
     const hasForm = mergedForm && mergedForm.length > 0
     if (hasData && hasForm) {
-      console.error('Cannot use -d/--data and -F/--form together. Choose one.')
+      console.error(
+        'Cannot use -d/--data and -F/--form together.\n' +
+          '  Use -d for raw/JSON data: curly -d \'{"key":"val"}\' URL\n' +
+          "  Use -F for multipart form uploads: curly -F 'file=@photo.jpg' URL",
+      )
       process.exit(1)
     }
 

--- a/src/lib/cli/parser.ts
+++ b/src/lib/cli/parser.ts
@@ -1,72 +1,92 @@
 import { parseArgs } from 'node:util'
+import { suggestFlag } from '../utils/errors'
+
+const CLI_OPTIONS = {
+  help: { type: 'boolean' as const, short: 'h', default: false },
+  version: { type: 'boolean' as const, short: 'V', default: false },
+  history: { type: 'boolean' as const, default: false },
+  'history-clear': { type: 'boolean' as const, default: false },
+  'history-search': { type: 'string' as const },
+  method: {
+    type: 'string' as const,
+    short: 'X',
+  },
+  headers: {
+    type: 'string' as const,
+    short: 'H',
+    multiple: true,
+  },
+  include: {
+    type: 'boolean' as const,
+    short: 'i',
+  },
+  output: {
+    type: 'string' as const,
+    short: 'o',
+  },
+  cookie: {
+    type: 'string' as const,
+    short: 'b',
+    multiple: true,
+  },
+  'cookie-jar': {
+    type: 'string' as const,
+  },
+  head: {
+    type: 'boolean' as const,
+    short: 'I',
+  },
+  data: { type: 'string' as const, short: 'd', multiple: true },
+  'data-raw': { type: 'string' as const },
+  query: { type: 'string' as const, short: 'q', multiple: true },
+  verbose: { type: 'boolean' as const, short: 'v', default: false },
+  quiet: { type: 'boolean' as const, default: false },
+  requests: { type: 'string' as const, short: 'n' },
+  concurrency: { type: 'string' as const, short: 'c' },
+  timeout: { type: 'string' as const, short: 't' },
+  follow: { type: 'boolean' as const, short: 'L', default: false },
+  'max-redirects': { type: 'string' as const },
+  fail: { type: 'boolean' as const, short: 'f', default: false },
+  user: { type: 'string' as const, short: 'u' },
+  retry: { type: 'string' as const, default: '0' },
+  'retry-delay': { type: 'string' as const, default: '1000' },
+  profile: { type: 'string' as const, short: 'p' },
+  completions: { type: 'string' as const },
+  save: { type: 'string' as const },
+  use: { type: 'string' as const },
+  aliases: { type: 'boolean' as const, default: false },
+  'delete-alias': { type: 'string' as const },
+  form: { type: 'string' as const, short: 'F', multiple: true },
+  proxy: { type: 'string' as const, short: 'x' },
+  'write-out': { type: 'string' as const, short: 'w' },
+  tui: { type: 'boolean' as const, short: 'T' },
+  'tui-compact': { type: 'boolean' as const, default: false },
+  'dry-run': { type: 'boolean' as const, default: false },
+  json: { type: 'boolean' as const, short: 'j', default: false },
+  export: { type: 'string' as const, short: 'e' },
+  init: { type: 'boolean' as const, default: false },
+}
+
+const KNOWN_FLAGS = Object.keys(CLI_OPTIONS)
 
 export function cli() {
-  return parseArgs({
-    options: {
-      help: { type: 'boolean', short: 'h', default: false },
-      version: { type: 'boolean', short: 'V', default: false },
-      history: { type: 'boolean', default: false },
-      'history-clear': { type: 'boolean', default: false },
-      'history-search': { type: 'string' },
-      method: {
-        type: 'string',
-        short: 'X',
-      },
-      headers: {
-        type: 'string',
-        short: 'H',
-        multiple: true,
-      },
-      include: {
-        type: 'boolean',
-        short: 'i',
-      },
-      output: {
-        type: 'string',
-        short: 'o',
-      },
-      cookie: {
-        type: 'string',
-        short: 'b',
-        multiple: true,
-      },
-      'cookie-jar': {
-        type: 'string',
-      },
-      head: {
-        type: 'boolean',
-        short: 'I',
-      },
-      data: { type: 'string', short: 'd', multiple: true },
-      'data-raw': { type: 'string' },
-      query: { type: 'string', short: 'q', multiple: true },
-      verbose: { type: 'boolean', short: 'v', default: false },
-      quiet: { type: 'boolean', default: false },
-      requests: { type: 'string', short: 'n' },
-      concurrency: { type: 'string', short: 'c' },
-      timeout: { type: 'string', short: 't' },
-      follow: { type: 'boolean', short: 'L', default: false },
-      'max-redirects': { type: 'string' },
-      fail: { type: 'boolean', short: 'f', default: false },
-      user: { type: 'string', short: 'u' },
-      retry: { type: 'string', default: '0' },
-      'retry-delay': { type: 'string', default: '1000' },
-      profile: { type: 'string', short: 'p' },
-      completions: { type: 'string' },
-      save: { type: 'string' },
-      use: { type: 'string' },
-      aliases: { type: 'boolean', default: false },
-      'delete-alias': { type: 'string' },
-      form: { type: 'string', short: 'F', multiple: true },
-      proxy: { type: 'string', short: 'x' },
-      'write-out': { type: 'string', short: 'w' },
-      tui: { type: 'boolean', short: 'T' },
-      'tui-compact': { type: 'boolean', default: false },
-      'dry-run': { type: 'boolean', default: false },
-      json: { type: 'boolean', short: 'j', default: false },
-      export: { type: 'string', short: 'e' },
-      init: { type: 'boolean', default: false },
-    },
-    allowPositionals: true,
-  })
+  try {
+    return parseArgs({
+      options: CLI_OPTIONS,
+      allowPositionals: true,
+    })
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      const unknownMatch = error.message.match(/Unknown option '(--.+?)'/)
+      if (unknownMatch) {
+        const unknownFlag = unknownMatch[1]
+        const suggestion = suggestFlag(unknownFlag, KNOWN_FLAGS)
+        if (suggestion) {
+          console.error(`Unknown option '${unknownFlag}'. Did you mean ${suggestion}?`)
+          process.exit(1)
+        }
+      }
+    }
+    throw error
+  }
 }

--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -5,11 +5,14 @@ import { isNodeError } from '../../types'
  * These replace cryptic system errors with actionable guidance.
  */
 const FRIENDLY_ERRORS: Record<string, string> = {
-  ECONNREFUSED: 'Connection refused — is the server running?',
+  ECONNREFUSED:
+    'Connection refused — is the server running?\n  Hint: Check that the server is running and the port is correct.',
   ECONNRESET: 'Connection was reset by the server',
   ECONNABORTED: 'Connection was aborted',
-  ETIMEDOUT: 'Connection timed out — the server took too long to respond',
-  ENOTFOUND: 'DNS lookup failed — check the hostname for typos',
+  ETIMEDOUT:
+    'Connection timed out — the server took too long to respond.\n  Hint: Try increasing the timeout with --timeout <ms>.',
+  ENOTFOUND:
+    'DNS lookup failed — check the hostname for typos.\n  Hint: Verify the domain is correct and your network connection is active.',
   EHOSTUNREACH: 'Host is unreachable — check your network connection',
   ENETUNREACH: 'Network is unreachable — check your internet connection',
   CERT_HAS_EXPIRED: 'SSL certificate has expired',
@@ -26,4 +29,77 @@ const FRIENDLY_ERRORS: Record<string, string> = {
 export function getFriendlyErrorMessage(error: unknown): string | null {
   if (!isNodeError(error) || !error.code) return null
   return FRIENDLY_ERRORS[error.code] ?? null
+}
+
+/**
+ * Maps HTTP status codes to actionable hints for --fail mode.
+ */
+const HTTP_STATUS_HINTS: Record<number, string> = {
+  400: 'The request was malformed. Check your data format and required fields.',
+  401: 'Authentication required. Try -u user:pass or -H "Authorization: Bearer <token>".',
+  403: 'Access forbidden. You may lack permission or need different credentials.',
+  404: 'Resource not found. Check the URL path for typos.',
+  405: 'HTTP method not allowed. Try a different method with -X (GET, POST, PUT, DELETE).',
+  408: 'The server timed out waiting for the request.',
+  409: 'Conflict with the current state of the resource.',
+  413: 'Request body too large. Try sending less data.',
+  415: 'Unsupported media type. Try setting Content-Type with -H "Content-Type: application/json".',
+  422: 'Unprocessable entity. The server understood the request but the data is invalid.',
+  429: 'Too many requests. Try again later or add a delay between requests.',
+  500: 'Internal server error. This is a problem on the server side.',
+  502: 'Bad gateway. The upstream server may be down.',
+  503: 'Service unavailable. The server may be overloaded or under maintenance.',
+  504: 'Gateway timeout. The upstream server did not respond in time.',
+}
+
+/**
+ * Returns a hint for a given HTTP status code, or null if not recognized.
+ */
+export function getHttpStatusHint(status: number): string | null {
+  return HTTP_STATUS_HINTS[status] ?? null
+}
+
+/**
+ * Returns the closest matching flag name using Levenshtein distance,
+ * or null if no close match is found.
+ */
+export function suggestFlag(unknown: string, knownFlags: string[]): string | null {
+  const flag = unknown.replace(/^-+/, '')
+  let bestMatch: string | null = null
+  let bestDistance = Infinity
+
+  for (const known of knownFlags) {
+    const d = levenshtein(flag, known)
+    if (d < bestDistance) {
+      bestDistance = d
+      bestMatch = known
+    }
+  }
+
+  // Only suggest if the distance is reasonable (at most ~40% of the flag length)
+  const maxDistance = Math.max(2, Math.floor(flag.length * 0.4))
+  if (bestMatch && bestDistance <= maxDistance) {
+    return `--${bestMatch}`
+  }
+  return null
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[])
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    }
+  }
+
+  return dp[m][n]
 }


### PR DESCRIPTION
Improve user experience when errors occur by providing contextual hints:
- Unknown flags now suggest the closest match (e.g., --folow → --follow)
- HTTP status errors with --fail show actionable hints (401 → try -u, 404 → check URL)
- Redirect responses without --follow suggest using -L/--follow
- Conflicting -d and -F flags explain the difference with examples
- Network errors (ECONNREFUSED, ETIMEDOUT, ENOTFOUND) include troubleshooting hints
- Missing URL message now shows usage hint

https://claude.ai/code/session_01FT3pCpCapUH7X6BYBDBQjK