### PR TITLE
Add --data-urlencode flag for URL-encoded form data

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,25 @@ curly -X POST -d title="Hello" -d body="World" https://api.example.com/posts
 curly -X POST --data-raw '{"title": "Hello", "body": "World"}' https://api.example.com/posts
 ```
 
+**URL-encoded form data** (`application/x-www-form-urlencoded`):
+
+```sh
+# Value is percent-encoded (spaces, &, +, unicode, etc. handled automatically)
+curly --data-urlencode "q=hello world & goodbye" https://api.example.com/search
+# Sends: q=hello%20world%20%26%20goodbye
+
+# Encode only the value, keep the key literal
+curly --data-urlencode "email=user+test@example.com" https://api.example.com/signup
+
+# Read a value from a file
+curly --data-urlencode "body@message.txt" https://api.example.com/posts
+
+# Multiple fields
+curly --data-urlencode "name=Jane Doe" \
+      --data-urlencode "city=São Paulo" \
+      https://api.example.com/users
+```
+
 **From file**:
 
 ```sh
@@ -393,6 +412,7 @@ source ~/.zshrc    # zsh
 | `--headers` | `-H` | Add custom headers (repeatable) |
 | `--data` | `-d` | Key=value pairs or @filename (repeatable) |
 | `--data-raw` | | Send raw data |
+| `--data-urlencode` | | URL-encoded form data (repeatable) |
 | `--form` | `-F` | Multipart form data (repeatable) |
 | `--query` | `-q` | Query parameters (repeatable) |
 | `--cookie` | `-b` | Cookies (key=value or file path, repeatable) |

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Core quality improvements that make the tool feel solid and production-ready.
 Important curl features that users expect from a curl-like tool.
 
 ### Request Body Improvements
-- [ ] `--data-urlencode` flag for URL-encoded form data
+- ~~`--data-urlencode` flag for URL-encoded form data~~ ✓
 - [ ] `--data-binary @file` to send file contents as-is (no stripping)
 - ~~`--json` flag as shortcut (sets Content-Type + Accept to application/json, like curl 7.82+)~~ ✓ (implemented as `-j`/`--json` structured JSON output flag)
 - [ ] Support reading request body from stdin (`-d @-`)

--- a/examples/03-data-and-forms.sh
+++ b/examples/03-data-and-forms.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # 03-data-and-forms.sh - Request Data and Form Submissions
 # =============================================================================
-# Demonstrates: -d/--data, --data-raw, -F/--form, file references (@file)
+# Demonstrates: -d/--data, --data-raw, --data-urlencode, -F/--form, file references (@file)
 # API: httpbin.org
 # =============================================================================
 
@@ -91,6 +91,31 @@ echo ""
 echo ""
 
 # -----------------------------------------------------------------------------
+# URL-Encoded Data (--data-urlencode)
+# -----------------------------------------------------------------------------
+
+echo "9a. URL-encoded value with spaces and special chars"
+echo "    Command: curly https://httpbin.org/post --data-urlencode \"q=hello world & goodbye\""
+echo "    ---"
+curly https://httpbin.org/post --data-urlencode "q=hello world & goodbye"
+echo ""
+echo ""
+
+echo "9b. URL-encoded value only (name=value keeps name literal)"
+echo "    Command: curly https://httpbin.org/post --data-urlencode \"email=user+test@example.com\""
+echo "    ---"
+curly https://httpbin.org/post --data-urlencode "email=user+test@example.com"
+echo ""
+echo ""
+
+echo "9c. Multiple URL-encoded fields (joined with &)"
+echo "    Command: curly https://httpbin.org/post --data-urlencode \"name=Jane Doe\" --data-urlencode \"city=São Paulo\""
+echo "    ---"
+curly https://httpbin.org/post --data-urlencode "name=Jane Doe" --data-urlencode "city=São Paulo"
+echo ""
+echo ""
+
+# -----------------------------------------------------------------------------
 # Form Data (-F/--form)
 # -----------------------------------------------------------------------------
 
@@ -156,11 +181,17 @@ echo ""
 echo "  Raw Data (--data-raw):"
 echo "    --data-raw '{...}'   Send raw JSON/XML/text"
 echo ""
+echo "  URL-Encoded Data (--data-urlencode):"
+echo "    --data-urlencode 'k=v'   Encode value, keep key literal"
+echo "    --data-urlencode 'v'     Encode entire string"
+echo "    --data-urlencode 'k@f'   Encode file contents with key prefix"
+echo ""
 echo "  Form Data (-F/--form):"
 echo "    -F field=value       Form field"
 echo "    -F file=@path        File upload"
 echo ""
 echo "  Content-Type is auto-detected:"
 echo "    -d sets application/json"
+echo "    --data-urlencode sets application/x-www-form-urlencoded"
 echo "    -F sets multipart/form-data"
 echo ""

--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -222,6 +222,16 @@ run_test "File upload (-F @file)" \
 run_test "Data from file (-d @file)" \
     "curly https://httpbin.org/post -d @${SCRIPT_DIR}/sample-data/data.json --quiet"
 
+run_test "URL-encoded data (--data-urlencode)" \
+    "curly https://httpbin.org/post --data-urlencode 'q=hello world & goodbye' --quiet"
+
+run_test "URL-encoded multiple fields" \
+    "curly https://httpbin.org/post --data-urlencode 'name=Jane Doe' --data-urlencode 'email=user+test@example.com' --quiet"
+
+run_test_output "URL-encoded sets form-urlencoded Content-Type" \
+    "curly https://httpbin.org/post --data-urlencode 'q=hello world' --quiet" \
+    "application/x-www-form-urlencoded"
+
 # -----------------------------------------------------------------------------
 # 4. QUERY PARAMETERS
 # -----------------------------------------------------------------------------

--- a/src/commands/completions/scripts.ts
+++ b/src/commands/completions/scripts.ts
@@ -22,6 +22,7 @@ const OPTIONS = [
   '--data',
   '-d',
   '--data-raw',
+  '--data-urlencode',
   '--query',
   '-q',
   '--output',
@@ -96,7 +97,7 @@ _curly_completions() {
             COMPREPLY=( $(compgen -W "\${methods}" -- "\${cur}") )
             return 0
             ;;
-        -o|--output|-b|--cookie|--cookie-jar|-d|--data|-F|--form)
+        -o|--output|-b|--cookie|--cookie-jar|-d|--data|--data-urlencode|-F|--form)
             # File completion
             COMPREPLY=( $(compgen -f -- "\${cur}") )
             return 0
@@ -201,6 +202,7 @@ _curly() {
         '*'{-H,--headers}'[Add header]:header:' \\
         '*'{-d,--data}'[Request data]:data:_files' \\
         '--data-raw[Raw request data]:data:' \\
+        '*--data-urlencode[URL-encoded form data]:data:_files' \\
         '*'{-q,--query}'[Query parameter]:query:' \\
         '(-o --output)'{-o,--output}'[Output file]:file:_files' \\
         '*'{-b,--cookie}'[Cookie]:cookie:_files' \\

--- a/src/core/http/client.ts
+++ b/src/core/http/client.ts
@@ -597,29 +597,25 @@ export function buildUrlEncodedBody(entries: string[]): string {
 }
 
 function encodeDataUrlencodeEntry(entry: string): string {
-  if (entry.startsWith('=')) {
-    return encodeURIComponent(entry.slice(1))
-  }
-
-  if (entry.startsWith('@')) {
-    const filePath = entry.slice(1)
-    return encodeURIComponent(readBodyFromFile(filePath))
-  }
-
   const eqIdx = entry.indexOf('=')
   const atIdx = entry.indexOf('@')
 
+  // No separator: encode the entire entry as the value
   if (eqIdx === -1 && atIdx === -1) {
     return encodeURIComponent(entry)
   }
 
+  // Split on the earliest separator. '=' means the rest is a literal value;
+  // '@' means the rest is a file path whose contents become the value.
   const useEquals = eqIdx !== -1 && (atIdx === -1 || eqIdx < atIdx)
   const sepIdx = useEquals ? eqIdx : atIdx
   const name = entry.slice(0, sepIdx)
   const rest = entry.slice(sepIdx + 1)
   const value = useEquals ? rest : readBodyFromFile(rest)
+  const encoded = encodeURIComponent(value)
 
-  return `${name}=${encodeURIComponent(value)}`
+  // Empty name (e.g. "=content" or "@file") → no prefix
+  return name ? `${name}=${encoded}` : encoded
 }
 
 export function buildBody(options: FetchOptions): string | undefined {

--- a/src/core/http/client.ts
+++ b/src/core/http/client.ts
@@ -458,7 +458,8 @@ export function buildMethod(options: FetchOptions): string {
   } else if (
     (options.data && options.data.length > 0) ||
     options['data-raw'] ||
-    (options.form && options.form.length > 0)
+    (options.form && options.form.length > 0) ||
+    (options['data-urlencode'] && options['data-urlencode'].length > 0)
   ) {
     return 'POST'
   } else {
@@ -483,7 +484,10 @@ export function buildMethod(options: FetchOptions): string {
  * headers created: {'Content-Type': 'application/json', 'foo': 'bar', 'cookie': 'VALUE1;VALUE2'}
  */
 export function buildHeaders(options: FetchOptions): Record<string, string> {
-  if (!options.headers && (options.data || options['data-raw'])) {
+  if (!options.headers && (options.data || options['data-raw'] || options['data-urlencode'])) {
+    if (options['data-urlencode'] && options['data-urlencode'].length > 0) {
+      return { 'Content-Type': 'application/x-www-form-urlencoded' }
+    }
     if (options.data?.length === 1 && options.data[0].startsWith('@')) {
       const filePath = options.data[0].slice(1)
       const contentType = getContentTypeFromExtension(filePath) ?? 'application/json'
@@ -578,7 +582,51 @@ function buildAuthHeader(options: FetchOptions): { Authorization: string } | und
   return { Authorization: `Basic ${encoded}` }
 }
 
+/**
+ * Builds a URL-encoded request body from --data-urlencode entries.
+ * Supported entry forms (matching curl's behavior):
+ *   "content"       → encode content as-is, no name prefix
+ *   "=content"      → encode content, no name prefix (explicit form)
+ *   "name=value"    → name=<encoded value> (name stays literal)
+ *   "@file"         → read file, encode contents, no name prefix
+ *   "name@file"     → name=<encoded file contents>
+ * Multiple entries are joined with '&'.
+ */
+export function buildUrlEncodedBody(entries: string[]): string {
+  return entries.map(encodeDataUrlencodeEntry).join('&')
+}
+
+function encodeDataUrlencodeEntry(entry: string): string {
+  if (entry.startsWith('=')) {
+    return encodeURIComponent(entry.slice(1))
+  }
+
+  if (entry.startsWith('@')) {
+    const filePath = entry.slice(1)
+    return encodeURIComponent(readBodyFromFile(filePath))
+  }
+
+  const eqIdx = entry.indexOf('=')
+  const atIdx = entry.indexOf('@')
+
+  if (eqIdx === -1 && atIdx === -1) {
+    return encodeURIComponent(entry)
+  }
+
+  const useEquals = eqIdx !== -1 && (atIdx === -1 || eqIdx < atIdx)
+  const sepIdx = useEquals ? eqIdx : atIdx
+  const name = entry.slice(0, sepIdx)
+  const rest = entry.slice(sepIdx + 1)
+  const value = useEquals ? rest : readBodyFromFile(rest)
+
+  return `${name}=${encodeURIComponent(value)}`
+}
+
 export function buildBody(options: FetchOptions): string | undefined {
+  if (options['data-urlencode'] && options['data-urlencode'].length > 0) {
+    return buildUrlEncodedBody(options['data-urlencode'])
+  }
+
   if ((!options.data || options.data.length === 0) && !options['data-raw']) return undefined
 
   if (options['data-raw']) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,14 +121,28 @@ export async function main(): Promise<void> {
     const mergedCookies = mergeInterpolatedArrays(alias?.cookie, cliFlags.cookie)
     const mergedQuery = mergeInterpolatedArrays(alias?.query, cliFlags.query)
     const mergedForm = mergeInterpolatedArrays(alias?.form, cliFlags.form)
+    const mergedDataUrlencode = mergeInterpolatedArrays(
+      alias?.['data-urlencode'],
+      cliFlags['data-urlencode'],
+    )
 
     const hasData = (mergedData && mergedData.length > 0) || cliFlags['data-raw']
     const hasForm = mergedForm && mergedForm.length > 0
+    const hasUrlencode = mergedDataUrlencode && mergedDataUrlencode.length > 0
     if (hasData && hasForm) {
       console.error(
         'Cannot use -d/--data and -F/--form together.\n' +
           '  Use -d for raw/JSON data: curly -d \'{"key":"val"}\' URL\n' +
           "  Use -F for multipart form uploads: curly -F 'file=@photo.jpg' URL",
+      )
+      process.exit(1)
+    }
+    if (hasUrlencode && (hasData || hasForm)) {
+      console.error(
+        'Cannot use --data-urlencode together with -d/--data, --data-raw, or -F/--form.\n' +
+          '  --data-urlencode sends application/x-www-form-urlencoded\n' +
+          '  -d/--data-raw send application/json\n' +
+          '  -F/--form sends multipart/form-data',
       )
       process.exit(1)
     }
@@ -139,6 +153,7 @@ export async function main(): Promise<void> {
       headers: mergedHeaders,
       data: mergedData,
       'data-raw': cliFlags['data-raw'] ? interpolate(cliFlags['data-raw']) : undefined,
+      'data-urlencode': mergedDataUrlencode,
       cookie: mergedCookies,
       query: mergedQuery,
       form: mergedForm,
@@ -164,6 +179,7 @@ export async function main(): Promise<void> {
         method: cliFlags.method,
         headers: cliFlags.headers,
         data: cliFlags.data,
+        'data-urlencode': cliFlags['data-urlencode'],
         query: cliFlags.query,
         cookie: cliFlags.cookie,
         form: cliFlags.form,

--- a/src/lib/cli/help.ts
+++ b/src/lib/cli/help.ts
@@ -17,6 +17,17 @@ Options:
   --data-raw <data>            Raw data input
                                Example: curly --data-raw '{"name": "Connor"}' https://example.com/api
 
+  --data-urlencode <data>      URL-encode value before sending (application/x-www-form-urlencoded)
+                               Entry forms:
+                                 content         encode content, no name prefix
+                                 =content        encode content, no name prefix
+                                 name=value      name=<encoded value>
+                                 @file           encode file contents, no name prefix
+                                 name@file       name=<encoded file contents>
+                               Example: curly --data-urlencode "q=hello world" https://example.com/search
+                               Example: curly --data-urlencode "email=user+test@example.com" https://example.com/api
+                               Example: curly --data-urlencode "body@message.txt" https://example.com/api
+
   -F, --form <name=value>      Multipart form data (use @file for uploads)
                                Example: curly -F "file=@photo.jpg" -F "name=vacation" https://example.com/upload
                                Cannot be used with -d or --data-raw

--- a/src/lib/cli/parser.ts
+++ b/src/lib/cli/parser.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from 'node:util'
+import { type FetchOptions } from '../../types'
 import { suggestFlag } from '../utils/errors'
 
 const CLI_OPTIONS = {
@@ -71,12 +72,20 @@ const CLI_OPTIONS = {
 
 const KNOWN_FLAGS = Object.keys(CLI_OPTIONS)
 
-export function cli() {
+export interface ParsedCli {
+  values: FetchOptions
+  positionals: string[]
+}
+
+export function cli(): ParsedCli {
   try {
+    // parseArgs types multi-value options as `string | string[]`, but with
+    // `multiple: true` the runtime always yields `string[]`. Cast to the
+    // narrower FetchOptions shape the rest of the codebase expects.
     return parseArgs({
       options: CLI_OPTIONS,
       allowPositionals: true,
-    })
+    }) as unknown as ParsedCli
   } catch (error: unknown) {
     if (error instanceof Error) {
       const unknownMatch = error.message.match(/Unknown option '(--.+?)'/)

--- a/src/lib/cli/parser.ts
+++ b/src/lib/cli/parser.ts
@@ -38,6 +38,7 @@ const CLI_OPTIONS = {
   },
   data: { type: 'string' as const, short: 'd', multiple: true },
   'data-raw': { type: 'string' as const },
+  'data-urlencode': { type: 'string' as const, multiple: true },
   query: { type: 'string' as const, short: 'q', multiple: true },
   verbose: { type: 'boolean' as const, short: 'v', default: false },
   quiet: { type: 'boolean' as const, default: false },

--- a/src/lib/utils/aliases.ts
+++ b/src/lib/utils/aliases.ts
@@ -10,6 +10,7 @@ export interface SavedAlias {
   method?: string
   headers?: string[]
   data?: string[]
+  'data-urlencode'?: string[]
   query?: string[]
   cookie?: string[]
   form?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface FetchOptions {
   head?: boolean
   data?: string[]
   'data-raw'?: string
+  'data-urlencode'?: string[]
   query?: string[]
   verbose?: boolean
   quiet?: boolean


### PR DESCRIPTION
Supports curl-compatible entry forms for sending
application/x-www-form-urlencoded bodies:

  content      encode string, no name prefix
  =content     encode string, no name prefix (explicit)
  name=value   name=<encoded value>
  @file        encode file contents, no name prefix
  name@file    name=<encoded file contents>

Multiple --data-urlencode entries are joined with '&'.
Content-Type is auto-set to application/x-www-form-urlencoded.
Conflicts with -d/--data-raw/-F are rejected with a clear error.

https://claude.ai/code/session_018eJ8FBUxacX31Eo6CmMVgq