### PR TITLE
Fix data-loss bugs in parsers and improve error handling

### DIFF
--- a/src/core/config/constants.ts
+++ b/src/core/config/constants.ts
@@ -5,6 +5,13 @@
  */
 export const HTTP_ERROR_EXIT_CODE = 22
 
+/**
+ * Exit code for request timeouts.
+ * Matches curl's exit code 28 for operation timeout.
+ * @see https://curl.se/docs/manpage.html#EXIT-CODES
+ */
+export const TIMEOUT_EXIT_CODE = 28
+
 export const CONTENT_TYPES = {
   text: ['text/html', 'application/xml', 'application/xhtml+xml'],
   json: ['application/json'],

--- a/src/core/http/client.ts
+++ b/src/core/http/client.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'fs'
 import { performance as perf } from 'node:perf_hooks'
 import { styleText } from 'node:util'
 import { ProxyAgent } from 'undici'
-import { getContentTypeFromExtension, parseFormField, readBodyFromFile } from '../../lib/utils/file'
+import {
+  getContentTypeFromExtension,
+  parseFormField,
+  readBodyFromFile,
+  readFileAsBuffer,
+} from '../../lib/utils/file'
 import { logger } from '../../lib/utils/logger'
 import { formatBytes, parseIntOption } from '../../lib/utils/parse'
 import { withRetry } from '../../lib/utils/retry'
@@ -15,7 +20,7 @@ import {
   isError,
 } from '../../types'
 import { getFriendlyErrorMessage } from '../../lib/utils/errors'
-import { CONTENT_TYPES } from '../config/constants'
+import { CONTENT_TYPES, TIMEOUT_EXIT_CODE } from '../config/constants'
 import { applyCookieHeader } from './cookies'
 
 export type { FetchOptions } from '../../types'
@@ -108,7 +113,7 @@ export async function curl(
     if (isError(error) && error.name === 'AbortError') {
       const wasExternalAbort = externalSignal?.aborted
       if (!wasExternalAbort && timeoutMs) {
-        logger().error(`Request timed out after ${timeoutMs}ms`)
+        logger().error(`Request timed out after ${timeoutMs}ms`, TIMEOUT_EXIT_CODE)
       }
       throw error
     }
@@ -389,11 +394,15 @@ export function buildUrl(url: string, queryParams: FetchOptions['query']): strin
   const urlWithQueryParams = new URL(url)
 
   for (const q of queryParams) {
-    if (!q.includes('=')) {
-      logger().error(`query params must be valid (e.g., -q foo=bar).`)
+    const eqIdx = q.indexOf('=')
+    if (eqIdx === -1) {
+      logger().error(
+        `Invalid query parameter: "${q}". Expected "key=value" (e.g., -q "search=hello")`,
+      )
     }
 
-    const [key, value] = q.split('=')
+    const key = q.slice(0, eqIdx)
+    const value = q.slice(eqIdx + 1)
     urlWithQueryParams.searchParams.append(key, value)
   }
 
@@ -432,7 +441,7 @@ export function buildFormData(formFields: string[]): FormData {
     const parsed = parseFormField(field)
 
     if (parsed.isFile) {
-      const fileBuffer = readFileSync(parsed.value)
+      const fileBuffer = readFileAsBuffer(parsed.value)
       const mimeType = getContentTypeFromExtension(parsed.value) ?? 'application/octet-stream'
       const blob = new Blob([fileBuffer], { type: mimeType })
 
@@ -498,15 +507,16 @@ export function buildHeaders(options: FetchOptions): Record<string, string> {
 
   const headers: Record<string, string> =
     options?.headers?.reduce((obj: Record<string, string>, h: string) => {
-      if (!h.includes(':')) {
-        logger().error('Headers are improperly formatted.')
-      } else if (h.toLowerCase().includes('cookie')) {
-        const [name, value] = h.split(/:(.+)/).map((part) => part.trim())
-        return { ...obj, [name]: value }
+      const colonIdx = h.indexOf(':')
+      if (colonIdx === -1) {
+        logger().error(
+          `Invalid header format: "${h}". Expected "Key: Value" (e.g., -H "Content-Type: application/json")`,
+        )
       }
 
-      const [key, value] = h.split(':')
-      return { ...obj, [key.trim()]: value.trim() }
+      const key = h.slice(0, colonIdx).trim()
+      const value = h.slice(colonIdx + 1).trim()
+      return { ...obj, [key]: value }
     }, {}) ?? {}
 
   return {
@@ -634,11 +644,15 @@ export function buildBody(options: FetchOptions): string | undefined {
     }
 
     const formattedData = options.data.reduce<Record<string, string>>((obj, d) => {
-      if (!d.includes('=')) {
-        logger().error('data must be formatted correctly (e.g., key1=value1).')
+      const eqIdx = d.indexOf('=')
+      if (eqIdx === -1) {
+        logger().error(
+          `Invalid data format: "${d}". Expected "key=value" (e.g., -d "name=John" -d "age=28")`,
+        )
       }
 
-      const [key, value] = d.split('=')
+      const key = d.slice(0, eqIdx)
+      const value = d.slice(eqIdx + 1)
       obj[key] = value
       return obj
     }, {})
@@ -667,6 +681,13 @@ function colorizeMethod(method: string): string {
   return styleText(color, method)
 }
 
+interface ResourceTimingEntry {
+  name: string
+  startTime: number
+  domainLookupEnd: number
+  connectEnd: number
+}
+
 /**
  * Attempts to collect DNS and connection timing from Node.js performance resource entries.
  * Falls back gracefully if resource timing data is not available.
@@ -676,8 +697,7 @@ function collectResourceTiming(
   _startTime: number,
 ): Pick<TimingData, 'timeNamelookup' | 'timeConnect'> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const entries = perf.getEntriesByType('resource') as any[]
+    const entries = perf.getEntriesByType('resource') as unknown as ResourceTimingEntry[]
     const entry = entries.findLast((e) => e.name === url)
 
     if (entry) {

--- a/src/core/http/cookies.ts
+++ b/src/core/http/cookies.ts
@@ -66,7 +66,11 @@ export function parseSetCookieHeaders(headers: Headers) {
 
   for (const cookie of setCookieHeaders) {
     const [nameAndValue] = cookie.split(';')
-    const [name, value] = nameAndValue.split('=')
+    const eqIdx = nameAndValue.indexOf('=')
+    if (eqIdx === -1) continue
+
+    const name = nameAndValue.slice(0, eqIdx).trim()
+    const value = nameAndValue.slice(eqIdx + 1).trim()
     cookieJar[name] = value
   }
 

--- a/src/lib/cli/help.ts
+++ b/src/lib/cli/help.ts
@@ -102,10 +102,10 @@ Options:
   --max-redirects <num>        Maximum number of redirects to follow (default: 20)
                                Example: curly -L --max-redirects 5 https://example.com
 
-  -n, --requests <num>         Number of requests for load testing
+  -n, --requests <num>         Number of requests for load testing (default: 200)
                                Example: curly -n 100 https://example.com
 
-  -c, --concurrency <num>      Concurrency level for load testing
+  -c, --concurrency <num>      Concurrency level for load testing (default: 50)
                                Example: curly -n 100 -c 10 https://example.com
 
   -T, --tui                    Enable interactive TUI dashboard for load testing

--- a/src/lib/cli/validation.ts
+++ b/src/lib/cli/validation.ts
@@ -33,6 +33,7 @@ export function validateOptions(url: string, options: FetchOptions): void {
   validateTimeout(options.timeout)
   validateMaxRedirects(options['max-redirects'])
   validateRetryOptions(options.retry, options['retry-delay'])
+  validateLoadTestOptions(options.requests, options.concurrency)
 }
 
 function validateHeaders(headers: string[] | undefined): void {
@@ -83,6 +84,28 @@ function validateMaxRedirects(value: string | undefined): void {
   const parsed = parseInt(value, 10)
   if (isNaN(parsed) || parsed < 0) {
     logger().error(`Invalid --max-redirects value "${value}". Must be a non-negative integer.`)
+  }
+}
+
+function validateLoadTestOptions(
+  requests: string | undefined,
+  concurrency: string | undefined,
+): void {
+  if (requests !== undefined) {
+    const parsed = parseInt(requests, 10)
+    if (isNaN(parsed) || parsed <= 0) {
+      logger().error(
+        `Invalid --requests value "${requests}". Must be a positive integer (e.g., -n 100).`,
+      )
+    }
+  }
+  if (concurrency !== undefined) {
+    const parsed = parseInt(concurrency, 10)
+    if (isNaN(parsed) || parsed <= 0) {
+      logger().error(
+        `Invalid --concurrency value "${concurrency}". Must be a positive integer (e.g., -c 10).`,
+      )
+    }
   }
 }
 

--- a/src/lib/output/formatters.ts
+++ b/src/lib/output/formatters.ts
@@ -3,6 +3,7 @@ import { createWriteStream } from 'node:fs'
 import { STATUS_CODES } from 'node:http'
 import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
+import { type ReadableStream as WebReadableStream } from 'node:stream/web'
 import { inspect, styleText } from 'node:util'
 import { type FetchOptions } from '../../core/http/client'
 import { parseSetCookieHeaders } from '../../core/http/cookies'
@@ -132,7 +133,7 @@ export async function streamDownload(response: Response, filePath: string) {
     }
   }
 
-  const nodeReadable = Readable.fromWeb(response.body as any)
+  const nodeReadable = Readable.fromWeb(response.body as WebReadableStream<Uint8Array>)
   const writeStream = createWriteStream(filePath)
   await pipeline(nodeReadable, progressTransform, writeStream)
 

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import { basename } from 'path'
+import { getErrorMessage, isNodeError } from '../../types'
 import { logger } from './logger'
 
 /**
@@ -59,11 +60,42 @@ export function isValidJson(str: unknown): boolean {
 }
 
 /**
+ * Exits with a friendly message for common filesystem errors.
+ * ENOENT → "File not found", EACCES → "Permission denied", other → generic.
+ */
+function exitOnFileError(filePath: string, error: unknown): never {
+  if (isNodeError(error) && error.code === 'ENOENT') {
+    return logger().error(`File not found: "${filePath}"`)
+  }
+  if (isNodeError(error) && error.code === 'EACCES') {
+    return logger().error(`Permission denied reading file: "${filePath}"`)
+  }
+  return logger().error(`Failed to read file "${filePath}": ${getErrorMessage(error)}`)
+}
+
+/**
  * Reads file contents to be used as a request body.
+ * Exits with a friendly error if the file is missing or unreadable.
  */
 export function readBodyFromFile(filePath: string): string {
   logger().verbose('request', `Reading request body from file: ${filePath}`)
-  return readFileSync(filePath, 'utf8')
+  try {
+    return readFileSync(filePath, 'utf8')
+  } catch (error: unknown) {
+    return exitOnFileError(filePath, error)
+  }
+}
+
+/**
+ * Reads file contents as a binary Buffer (e.g., for multipart uploads).
+ * Exits with a friendly error if the file is missing or unreadable.
+ */
+export function readFileAsBuffer(filePath: string): Buffer {
+  try {
+    return readFileSync(filePath)
+  } catch (error: unknown) {
+    return exitOnFileError(filePath, error)
+  }
 }
 
 /**

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -69,7 +69,7 @@ function formatLogMessage(level: LogLevel, args: string[]): string {
  * - `debug(...args)` - Logs debug info when DEBUG=true environment variable is set
  * - `info(...args)` - Logs informational messages
  * - `warn(...args)` - Logs warning messages
- * - `error(...args)` - Logs error messages and exits the process with code 1
+ * - `error(message, exitCode?)` - Logs error message and exits the process (default code 1)
  */
 export function logger() {
   return {
@@ -95,9 +95,9 @@ export function logger() {
       console.log(formatLogMessage('warn', args))
     },
 
-    error(...args: string[]): never {
-      console.log(formatLogMessage('error', args))
-      process.exit(1)
+    error(message: string, exitCode: number = 1): never {
+      console.log(formatLogMessage('error', [message]))
+      process.exit(exitCode)
     },
   }
 }


### PR DESCRIPTION
- buildBody/buildUrl/buildHeaders/parseSetCookieHeaders now use indexOf
  instead of split() so '=' and ':' in values are preserved
- readFileSync for -d @file and -F file=@path now surface ENOENT/EACCES
  as friendly errors instead of uncaught exceptions
- Request timeouts now exit with code 28 to match curl
- Invalid --requests and --concurrency values are rejected at validation
- Help text documents load-test defaults (200 requests, 50 concurrency)
- Replace 'as any' casts with proper types (Readable.fromWeb, perf entries)